### PR TITLE
Feature | Routes and bin:lib crate architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "hilow-social-feed-api"
+name = "hilow"
 version = "0.0.0"
 dependencies = [
  "actix-rt 2.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hilow-social-feed-api"
+name = "hilow"
 version = "0.0.0"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 edition = "2018"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,12 +1,9 @@
 #[macro_use]
 extern crate log;
 
-use actix_web::{get, web, App, HttpServer, Responder};
+use actix_web::{App, HttpServer};
 
-#[get("/{id}/{name}")]
-async fn index(web::Path((id, name)): web::Path<(u32, String)>) -> impl Responder {
-    format!("Hello {}! id:{}", name, id)
-}
+use hilow::router::router;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -18,7 +15,7 @@ async fn main() -> std::io::Result<()> {
     env_logger::init();
 
     info!("Serving on http://0.0.0.0:7878");
-    HttpServer::new(|| App::new().service(index))
+    HttpServer::new(|| App::new().configure(router))
         .bind("0.0.0.0:7878")?
         .run()
         .await

--- a/src/handlers/hello.rs
+++ b/src/handlers/hello.rs
@@ -1,0 +1,5 @@
+use actix_web::Responder;
+
+pub async fn hello() -> impl Responder {
+    String::from("Hello!")
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,3 @@
+mod hello;
+
+pub use hello::hello;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod handlers;
+pub mod router;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,8 @@
+use actix_web::web::{get, resource, ServiceConfig};
+
+use crate::handlers::hello;
+
+/// Registers HTTP services to the current server instance
+pub fn router(cfg: &mut ServiceConfig) {
+    cfg.service(resource("/hello").route(get().to(hello)));
+}


### PR DESCRIPTION
In order to provide a more HTTP server idiomatic structure
a "router" module is implemented in charge of "wiring up"
HTTP services to the main Actix instance.

The structure of the project is reworked as well to accomplish
a the Rust convention of disengaging executable logic from
application logic.

<!--
Thank you for your pull request. Please provide a description of your change.

Contributors guide: https://github.com/rust-lang-ve/rust-lang-ve.github.io/blob/HEAD/CONTRIBUTING.md
-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
