### PR TITLE
Fix docker devstack problems

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,12 @@
 .git/
 .github/
 .vscode/
+target/
 
 docker/volumes
 
 .gitignore
 *.swp
+
+*.md
+LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bundle
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Docker volumes
+docker/volumes/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,11 @@ services:
       context: .
       dockerfile: dev.Dockerfile
     env_file: .env.development
-    environment:
-      RUST_LOG: ${RUST_LOG}
     ports:
       - 7878:7878
     volumes:
-      - ${PWD}/src:/app/src
-      - ${PWD}/target:/app/target
-      - ${PWD}/Cargo.lock:/app/Cargo.lock
-      - ${PWD}/Cargo.toml:/app/Cargo.toml
+      - ${PWD}:/app
+      - ${PWD}/docker/volumes/target:/app/target
     restart: always
     depends_on:
       - database
@@ -22,10 +18,6 @@ services:
   database:
     image: postgres:13
     env_file: .env.development
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - 5432:5432
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - 7878:7878
     volumes:
       - ${PWD}:/app
-      - ${PWD}/docker/volumes/target:/app/target
     restart: always
     depends_on:
       - database


### PR DESCRIPTION
Right now, the docker devstack is having a couple of problems.

In one hand, it is not mounting the bin/ directory so it cannot run the entrypoint command. On the other hand, the .env.development never is passed to the running container, and therefore the code is failing.

I solved both of them, by mounting all the root of the project in the container.

I also removed the environment configuration from the services in the docker-compose since they are already being configured with the env_file configuration.

In order to check that this works, you can run:

`docker-compose up --build`